### PR TITLE
Fix Gallery.js crash if Image Ref is not ready yet

### DIFF
--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -175,7 +175,10 @@ export default class Gallery extends Component {
 
   getImageTransformer(page) {
     if (page >= 0 && page < this.pageCount) {
-      return this.imageRefs.get(page + '').getViewTransformerInstance();
+      let ref = this.imageRefs.get(page + '');
+      if (ref) {
+        return ref.getViewTransformerInstance();
+      }
     }
   }
 


### PR DESCRIPTION
Fix Gallery.js crash if Image Ref is not ready yet
