### PR TITLE
Pass props to Transformable Image

### DIFF
--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -237,6 +237,7 @@ export default class Gallery extends Component {
   renderPage(pageData, pageId, layout) {
     return (
       <Image
+        {...this.props}
         ref={this.onImageRef.bind(this, pageId)}
         key={'innerImage#' + pageId}
         style={{width: layout.width, height: layout.height}}

--- a/library/Gallery.js
+++ b/library/Gallery.js
@@ -235,9 +235,16 @@ export default class Gallery extends Component {
   }
 
   renderPage(pageData, pageId, layout) {
+    const { onViewTransformed, onTransformGestureReleased, ...other } = props;
     return (
       <Image
-        {...this.props}
+        {...other}
+        onViewTransformed={((transform) => {
+           onViewTransformed && onViewTransformed(transform, pageId);
+        }).bind(this)}
+        onTransformGestureReleased={((transform) => {
+           onTransformGestureReleased && onTransformGestureReleased(transform, pageId);
+        }).bind(this)}
         ref={this.onImageRef.bind(this, pageId)}
         key={'innerImage#' + pageId}
         style={{width: layout.width, height: layout.height}}


### PR DESCRIPTION
I wanted to be able to be notified `onViewTransformed` in [react-native-view-transformer](https://github.com/ldn0x7dc/react-native-view-transformer) so I added in passing the props to the component. This branch contains the code from @VansonLeung fork as well. If needed I can remove his code and only submit my changes.
